### PR TITLE
WIP: Fix incorrect select behaviour on row tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
-authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
 name = "TableOperations"
 uuid = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
+authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
 version = "0.2.0"
 
 [deps]

--- a/src/TableOperations.jl
+++ b/src/TableOperations.jl
@@ -144,8 +144,8 @@ struct SelectRow{T, names} <: Tables.AbstractRow
 end
 
 Tables.getcolumn(row::SelectRow, nm::Symbol) = Tables.getcolumn(getfield(row, 1), nm)
-Tables.getcolumn(row::SelectRow, i::Int) = Tables.getcolumn(getfield(row, 1), i)
-Tables.getcolumn(row::SelectRow, ::Type{T}, i::Int, nm::Symbol) where {T} = Tables.getcolumn(getfield(row, 1), T, i, nm)
+Tables.getcolumn(row::SelectRow{T, names}, i::Int) where {T, names} = Tables.getcolumn(getfield(row, 1), names[i])
+Tables.getcolumn(row::SelectRow, ::Type{T}, i::Int, nm::Symbol) where {T} = Tables.getcolumn(getfield(row, 1), T, Tables.columnindex(Tables.columnnames(getfield(row, 1)), nm), nm)
 
 getprops(row, nms::NTuple{N, Symbol}) where {N} = nms
 getprops(row, inds::NTuple{N, Int}) where {N} = ntuple(i->Tables.columnnames(getfield(row, 1))[inds[i]], N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,6 +162,7 @@ sel = rtable2 |> TableOperations.select(:B)
 @test isequal(Tables.rowtable(sel), [(B=1.0,), (B=2.0,), (B=3.0,)])
 srow = first(sel)
 @test propertynames(srow) == (:B,)
+@test srow.B == 2.0 # What we expect
 
 sel = rtable |> TableOperations.select(1)
 @test Tables.rowaccess(typeof(sel))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,25 @@ sel = rtable |> TableOperations.select(:A)
 srow = first(sel)
 @test propertynames(srow) == (:A,)
 
+# Testing issue where we always select the first column values, but using the correct name.
+# NOTE: We don't use rtable here because mixed types produce TypeErrors which hide the
+# underlying problem.
+rtable2 = [(A = 1.0, B = 2.0), (A = 2.0, B = 4.0), (A = 3.0, B = 6.0)]
+sel = rtable2 |> TableOperations.select(:B)
+@test Tables.rowaccess(typeof(sel))
+@test Tables.rows(sel) === sel
+@test Tables.schema(sel) == Tables.Schema((:B,), (Float64,))
+@test Base.IteratorSize(typeof(sel)) == Base.HasShape{1}()
+@test length(sel) == 3
+@test Base.IteratorEltype(typeof(sel)) == Base.HasEltype()
+@test eltype(sel) == TableOperations.SelectRow{NamedTuple{(:A, :B,),Tuple{Float64,Float64}},(:B,)}
+@test_broken isequal(Tables.columntable(sel), (B = B=[2.0, 4.0, 6.0],))
+@test_broken isequal(Tables.rowtable(sel), [(B=2.0,), (B=4.0,), (B=6.0,)])
+@test isequal(Tables.columntable(sel), (B = [1.0, 2.0, 3.0],))
+@test isequal(Tables.rowtable(sel), [(B=1.0,), (B=2.0,), (B=3.0,)])
+srow = first(sel)
+@test propertynames(srow) == (:B,)
+
 sel = rtable |> TableOperations.select(1)
 @test Tables.rowaccess(typeof(sel))
 @test Tables.rows(sel) === sel

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,10 +156,10 @@ sel = rtable2 |> TableOperations.select(:B)
 @test length(sel) == 3
 @test Base.IteratorEltype(typeof(sel)) == Base.HasEltype()
 @test eltype(sel) == TableOperations.SelectRow{NamedTuple{(:A, :B,),Tuple{Float64,Float64}},(:B,)}
-@test_broken isequal(Tables.columntable(sel), (B = B=[2.0, 4.0, 6.0],))
-@test_broken isequal(Tables.rowtable(sel), [(B=2.0,), (B=4.0,), (B=6.0,)])
-@test isequal(Tables.columntable(sel), (B = [1.0, 2.0, 3.0],))
-@test isequal(Tables.rowtable(sel), [(B=1.0,), (B=2.0,), (B=3.0,)])
+@test isequal(Tables.columntable(sel), (B = [2.0, 4.0, 6.0],))
+@test isequal(Tables.rowtable(sel), [(B=2.0,), (B=4.0,), (B=6.0,)])
+@test isequal(Tables.columntable(sel), (B = [2.0, 4.0, 6.0],))
+@test isequal(Tables.rowtable(sel), [(B=2.0,), (B=4.0,), (B=6.0,)])
 srow = first(sel)
 @test propertynames(srow) == (:B,)
 @test srow.B == 2.0 # What we expect


### PR DESCRIPTION
When selecting columns (except the first column) the returned table will use the first column values with the desired column header. I've provided tests demonstrating the issue, but I'm having difficulty following the select iteration code to figure out where the issue is coming from.