### PR TITLE
Start work on TableOperations.joinpartitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,12 @@ arch:
 
 julia:
   - 1.0
-  - 1.3
+  - 1
   - nightly
-
-env:
-  - JULIA_PROJECT="@."
 
 matrix:
   exclude:
     - os: osx
-      arch: x86
-    - os: linux
       arch: x86
   allow_failures:
   - julia: nightly
@@ -31,4 +26,11 @@ notifications:
   email: false
 
 after_success:
-   - julia -e 'ENV["TRAVIS_JULIA_VERSION"] == "1.3" && ENV["TRAVIS_OS_NAME"] != "linux" && exit(); using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+
+branches:
+  only:
+  - main
+  - gh-pages # For building documentation
+  - /^testing-.*$/ # testing branches
+  - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ after_success:
 
 branches:
   only:
-  - main
+  - master
   - gh-pages # For building documentation
   - /^testing-.*$/ # testing branches
   - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
 version = "0.2.1"
 
 [deps]
+SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Tables = "1"
+SentinelArrays = "1"
+Tables = "1.1"
 julia = "1"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,3 +278,16 @@ m = TableOperations.map(x->(A=x.A, C=x.C, B=x.B * 2), ctable)
 @test length(TableOperations.map(x->(A=x.A, C=x.C, B=x.B * 2), rtable) |> Tables.rowtable) == 3
 
 end
+
+@testset "TableOperations.joinpartitions" begin
+
+p = Tables.partitioner((ctable, ctable))
+j = TableOperations.joinpartitions(p)
+@test Tables.istable(j)
+@test Tables.columnaccess(j)
+@test Tables.schema(j) === Tables.schema(ctable)
+@test Tables.columnnames(j) == Tables.columnnames(ctable)
+@test isequal(Tables.getcolumn(j, 1), vcat(Tables.getcolumn(ctable, 1), Tables.getcolumn(ctable, 1)))
+@test isequal(Tables.getcolumn(j, :A), vcat(Tables.getcolumn(ctable, :A), Tables.getcolumn(ctable, :A)))
+
+end


### PR DESCRIPTION
With the new `Tables.partitions` functionality in the Tables.jl package,
it can be helpful for non-partitioned in-memory table structures to have
a way to treat the separate partitions as a single, long partition. The
SentinelArrays.jl package includes a `ChainedVector` type that allows
lazily "chaining" AbstractArrays together, treated as a single, long
vector. `TableOperations.joinpartitions(x)` takes any partitioned input
`x`, and appends the columns together via `ChainedVector`, producing a
`JoinedPartitions` object which itself, satisfies the `Tables.columns`
interface, i.e. you could do `df =
DataFrame(TableOperations.joinpartitions(x))` to concatenate all
partitions of the input and operate on them as a whole in a `DataFrame`.

Still need to add tests and docs.