### PR TITLE
start of narrow_types!() pull request using lazy eval

### DIFF
--- a/src/TableOperations.jl
+++ b/src/TableOperations.jl
@@ -303,4 +303,20 @@ end
 
 joinpartitions() = x -> joinpartitions(x)
 
+struct NarrowTypes{T}
+    x::T
+    schema::Tables.Schema
+end
+
+narrow_arr(x) = mapreduce(typeof, promote_type, x)
+narrow_types(t) = NarrowTypes(t, Tables.Schema(Tables.columnnames(t), [narrow_arr(getproperty(t, nm)) for nm in Tables.columnnames(t)]))
+
+Tables.getcolumn(nt::NarrowTypes, nm::Symbol) = Vector{getproperty(nt.schema.types, nm)}(Tables.getcolumn(getfield(nt, 1), nm))
+Tables.getcolumn(nt::NarrowTypes, i::Int) = Vector{nt.schema.types[i]}(Tables.getcolumn(getfield(nt, 1), i))
+
+Tables.columnnames(nt::NarrowTypes) = Tables.columnnames(getfield(nt, 1)) # or nt.sch.names?
+Tables.schema(nt::NarrowTypes) = nt.schema
+
+Tables.istable(::Type{<:NarrowTypes}) = true
+
 end # module


### PR DESCRIPTION
Attempt at solving #9 

I think adding a test or example will be important, as well as dealing with the fact that the x field in NarrowTypes will have an outdated schema. I'm not a huge fan of this, but I suppose that anyone with the intention of creating a NarrowTypes struct, will evaluate and receive just a Table with the narrowed schema.

Would love feedback!

Thanks

This is what I've enumerated as todos
- [ ] example/test
- [ ] docs/explanation of struct 
- [ ] specifying columns to narrow
- [ ] row access checking?
---
